### PR TITLE
receive tensors or numpy arrays

### DIFF
--- a/wirehead/generator.py
+++ b/wirehead/generator.py
@@ -6,6 +6,7 @@ import time
 import yaml
 import bson
 import torch
+import numpy as np
 from pymongo import MongoClient, ReturnDocument
 
 
@@ -80,9 +81,16 @@ class WireheadGenerator:
         binobj = data
         kinds = self.sample
         for i, kind in enumerate(kinds):
+            if isinstance(binobj[i], torch.Tensor):
+                payload = binobj[i]
+            elif isinstance(binobj[i], np.ndarray):
+                payload = torch.from_numpy(binobj[i])
+            else:
+                # It's neither a PyTorch tensor nor a NumPy array
+                raise TypeError(f"Unsupported type for binobj[{i}]: {type(binobj[i])}")
             chunks += list(
                 chunk_binobj(
-                    tensor2bin(torch.from_numpy(binobj[i])),
+                    tensor2bin(payload),
                     index,
                     kind,
                     self.chunksize,


### PR DESCRIPTION
With this little change the users are not required to push numpy arrays to wirehead and can push tensors directly, for example if they are using pytorch package like cornucopia to generate synthetic samples or otherwise prefer to convert their data to pytorch tensors themselves.